### PR TITLE
Updates to example SLURM / Singularity job script

### DIFF
--- a/content/use/singularity.md
+++ b/content/use/singularity.md
@@ -65,7 +65,21 @@ cat 1>&2 <<END
 
    user: ${USER}
    password: ${PASSWORD}
+
+When done using RStudio Server, terminate the job by:
+
+1. Exit the RStudio Session ("power" button in the top right corner of the RStudio window)
+2. Issue the following command on the login node:
+
+      scancel -f ${SLURM_JOB_ID}
 END
+
+# User-installed R packages go into their home directory
+if [ ! -e ${HOME}/.Renviron ]
+then
+  printf '\nNOTE: creating ~/.Renviron file\n\n'
+  echo 'R_LIBS_USER=~/R/%p-library/%v' >> ${HOME}/.Renviron
+fi
 
 # This example bind mounts the /project directory on the host into the Singularity container.
 # By default the only host file systems mounted within the container are $HOME, /tmp, /proc, /sys, and /dev.


### PR DESCRIPTION
A couple suggested updates to the SLURM job script based on user testing. In particular, the "power" button needs to be used to exit RStudio to avoid an error message after an scancel / sbatch / subsequent login; and package installation didn't work out-of-the-box when ~/.Renviron wasn't configured to install packages into the user's home directory (Singularity squashfs images are read-only).

Otherwise, I haven't noticed any odd hiccups with this configuration so far.