### PR TITLE
Change footer URLs to absolute

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -212,14 +212,14 @@
         
 
         <li>
-          <a href="./https:/github.com/rocker-org"><i class="button-icon fa fa-2x fa-github"></i>  GitHub</a>
+          <a href="https://github.com/rocker-org"><i class="button-icon fa fa-2x fa-github"></i>  GitHub</a>
         </li>
         
       
         
 
         <li>
-          <a href="./https:/hub.docker.com/u/rocker"><i class="button-icon fa fa-2x fa-docker"></i>  Docker Hub</a>
+          <a href="https://hub.docker.com/u/rocker"><i class="button-icon fa fa-2x fa-docker"></i>  Docker Hub</a>
         </li>
         
       


### PR DESCRIPTION
The Docker and GitHub links at the bottom of the page are returning 404s.