### PR TITLE
Update/singularity docs rstudio1.3

### DIFF
--- a/content/use/singularity.md
+++ b/content/use/singularity.md
@@ -28,13 +28,36 @@ listening on 127.0.0.1:8787.
 
 ### Running a Rocker Singularity container with password authentication
 
-To enable password authentication, set the PASSWORD environment variable and add the `--auth-none=0 --auth-pam-helper-path=pam-helper` options:
+To enable password authentication, set the PASSWORD environment variable and add the `--auth-none=0 --auth-pam-helper-path=pam-helper ` options:
 
 ```
 PASSWORD='...' singularity exec rstudio.simg rserver --auth-none=0  --auth-pam-helper-path=pam-helper
 ```
 
 After pointing your browser to http://_hostname_:8787, enter your local user ID on the system as the username, and the custom password specified in the PASSWORD environment variable.
+
+### Additional Options for RStudio >= 1.3.x
+
+RStudio 1.3.x wants to create a revocation-list file at (by default) /run/rstudio-server/revocation-list
+
+If you are working e.g. on an HPC-Cluster you might not have permission to create this file. 
+To work around, you can bind-mount a writable directory `myrun` to run:
+
+```
+--bind myrun:/run
+```
+
+A per-user /tmp should also be bind-mounted when running on a multi-tenant HPC cluster that has singularity configured to bind mount the host /tmp, to avoid the case where another user is or was running rstudio server on the same compute node, and created a /tmp/rstudio-server directory their own.
+
+In addition, RStudio >= 1.3.x enforces a stricter policy for session timeout, defaulting to 60 Minutes. You can opt in to the legacy behaviour by adding the following parameters:
+```
+--auth-timeout-minutes=0 --auth-stay-signed-in-days=30
+```
+
+The full call to run your rstudio server session with rstudio>=1.3.x might look like:
+```
+PASSWORD='...' singularity exec --bind myrun:/run --bind mytmp:/tmp rstudio.simg rserver --auth-none=0  --auth-pam-helper-path=pam-helper --auth-timeout-minutes=0 --auth-stay-signed-in-days=30
+```
 
 ### SLURM job script
 

--- a/content/use/singularity.md
+++ b/content/use/singularity.md
@@ -28,7 +28,7 @@ listening on 127.0.0.1:8787.
 
 ### Running a Rocker Singularity container with password authentication
 
-To enable password authentication, set the PASSWORD environment variable and add the `--auth-none=0 --auth-pam-helper-path=pam-helper ` options:
+To enable password authentication, set the PASSWORD environment variable and add the `--auth-none=0 --auth-pam-helper-path=pam-helper` options:
 
 ```
 PASSWORD='...' singularity exec rstudio.simg rserver --auth-none=0  --auth-pam-helper-path=pam-helper


### PR DESCRIPTION
As discussed in [this recent issue](https://github.com/rocker-org/rocker-versioned/issues/213), rocker-images with an rstudio version >= 1.3.x require additional options to be successfully run under singularity. This PR adds the recent findings to the official documentation on the rocker-website.  