### PR TITLE
Update Singularity guide for RStudio Server 1.4

### DIFF
--- a/content/use/singularity.md
+++ b/content/use/singularity.md
@@ -2,24 +2,30 @@
 title: "Singularity"
 ---
 
-[Singularity](http://singularity.lbl.gov/) is useful for running containers as an unprivileged user, especially in multi-user environments like High-Performance Computing clusters.
+[Singularity](https://www.sylabs.io/guides/latest/user-guide/) is useful for running containers as an unprivileged user, especially in multi-user environments like High-Performance Computing clusters.
 Rocker images can be imported and run using Singularity, with optional custom password support.
 
 ### Importing a Rocker Image
 
-Use the `singularity pull` command to import the desired Rocker image from Docker Hub into a SquashFS (compressed, read-only) image:
+Use the `singularity pull` command to import the desired Rocker image from Docker Hub into a (compressed, read-only) Singularity Image File:
 
 ```
-singularity pull --name rstudio.simg docker://rocker/rstudio:latest
+singularity pull docker://rocker/rstudio:4.0.4
 ```
 
-If additional Debian software packages are needed, see the Singularity documentation for building a [writable image](http://singularity.lbl.gov/docs-flow#writable-image) or [writable sandbox directory](http://singularity.lbl.gov/docs-flow#sandbox-folder) (note that sudo privileges are required).
-A writable image is not needed for installing R packages into a personal library in the user's home directory.
+If additional Debian (or other) software packages are needed, a Rocker base image can be extended in a [Singularity definition file](https://sylabs.io/guides/3.7/user-guide/definition_files.html).
+Note that sudo privileges are required to use the `singularity build` command, unless using a remote builder such as the [Sylabs Cloud Remote Builder](https://cloud.sylabs.io/builder).
+Alternatively, a Rocker base image can be extended in a Dockerfile and a Singularity image built using the [docker2singularity](https://github.com/singularityhub/docker2singularity) Docker image.
+Modifications to the base Rocker image are not needed for installing R packages into a personal library in the user's home directory.
 
 ### Running a Rocker Singularity container (localhost, no password)
 
 ```
-singularity exec rstudio.simg rserver --www-address=127.0.0.1
+mkdir -p run var-lib-rstudio-server
+
+printf 'provider=sqlite\ndirectory=/var/lib/rstudio-server\n' > database.conf
+
+singularity exec --bind run:/run,var-lib-rstudio-server:/var/lib/rstudio-server,database.conf:/etc/rstudio/database.conf rstudio_4.0.4.sif rserver --www-address=127.0.0.1
 ```
 
 This will run rserver in a Singularity container.
@@ -31,37 +37,23 @@ listening on 127.0.0.1:8787.
 To enable password authentication, set the PASSWORD environment variable and add the `--auth-none=0 --auth-pam-helper-path=pam-helper` options:
 
 ```
-PASSWORD='...' singularity exec rstudio.simg rserver --auth-none=0  --auth-pam-helper-path=pam-helper
+PASSWORD='...' singularity exec --bind run:/run,var-lib-rstudio-server:/var/lib/rstudio-server,database.conf:/etc/rstudio/database.conf rstudio_4.0.4.sif rserver --auth-none=0  --auth-pam-helper-path=pam-helper
 ```
 
 After pointing your browser to http://_hostname_:8787, enter your local user ID on the system as the username, and the custom password specified in the PASSWORD environment variable.
 
 ### Additional Options for RStudio >= 1.3.x
 
-RStudio 1.3.x wants to create a revocation-list file at (by default) /run/rstudio-server/revocation-list
-
-If you are working e.g. on an HPC-Cluster you might not have permission to create this file. 
-To work around, you can bind-mount a writable directory `myrun` to run:
-
-```
---bind myrun:/run
-```
-
-A per-user /tmp should also be bind-mounted when running on a multi-tenant HPC cluster that has singularity configured to bind mount the host /tmp, to avoid the case where another user is or was running rstudio server on the same compute node, and created a /tmp/rstudio-server directory their own.
-
 In addition, RStudio >= 1.3.x enforces a stricter policy for session timeout, defaulting to 60 Minutes. You can opt in to the legacy behaviour by adding the following parameters:
 ```
 --auth-timeout-minutes=0 --auth-stay-signed-in-days=30
 ```
 
-The full call to run your rstudio server session with rstudio>=1.3.x might look like:
-```
-PASSWORD='...' singularity exec --bind myrun:/run --bind mytmp:/tmp rstudio.simg rserver --auth-none=0  --auth-pam-helper-path=pam-helper --auth-timeout-minutes=0 --auth-stay-signed-in-days=30
-```
-
 ### SLURM job script
 
 On an HPC cluster, a Rocker Singularity container can be started on a compute node using the cluster's job scheduler, allowing it to access compute, memory, and storage resources that may far exceed those found in a typical desktop workstation.
+A per-user /tmp should be bind-mounted when running on a multi-tenant HPC cluster that has singularity configured to bind mount the host /tmp, to avoid an existing /tmp/rstudio-server owned by another user.
+
 The following example illustrates how this may be done with a SLURM job script.
 
 ```
@@ -69,25 +61,60 @@ The following example illustrates how this may be done with a SLURM job script.
 #SBATCH --time=08:00:00
 #SBATCH --signal=USR2
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-tasks=2
+#SBATCH --cpus-per-task=2
 #SBATCH --mem=8192
 #SBATCH --output=/home/%u/rstudio-server.job.%j
+# customize --output path as appropriate (to a directory readable only by the user!)
 
-export PASSWORD=$(openssl rand -base64 15)
+# Create temporary directory to be populated with directories to bind-mount in the container
+# where writable file systems are necessary. Adjust path as appropriate for your computing environment.
+workdir=$(python -c 'import tempfile; print(tempfile.mkdtemp())')
+
+mkdir -p -m 700 ${workdir}/run ${workdir}/tmp ${workdir}/var/lib/rstudio-server
+cat > ${workdir}/database.conf <<END
+provider=sqlite
+directory=/var/lib/rstudio-server
+END
+
+# Set OMP_NUM_THREADS to prevent OpenBLAS (and any other OpenMP-enhanced
+# libraries used by R) from spawning more threads than the number of processors
+# allocated to the job.
+#
+# Set R_LIBS_USER to a path specific to rocker/rstudio to avoid conflicts with
+# personal libraries from any R installation in the host environment
+
+cat > ${workdir}/rsession.sh <<END
+#!/bin/sh
+export OMP_NUM_THREADS=${SLURM_JOB_CPUS_PER_NODE}
+export R_LIBS_USER=${HOME}/R/rocker-rstudio/4.0
+exec rsession "\${@}"
+END
+
+chmod +x ${workdir}/rsession.sh
+
+export SINGULARITY_BIND="${workdir}/run:/run,${workdir}/tmp:/tmp,${workdir}/database.conf:/etc/rstudio/database.conf,${workdir}/rsession.sh:/etc/rstudio/rsession.sh,${workdir}/var/lib/rstudio-server:/var/lib/rstudio-server"
+
+# Do not suspend idle sessions.
+# Alternative to setting session-timeout-minutes=0 in /etc/rstudio/rsession.conf
+# https://github.com/rstudio/rstudio/blob/v1.4.1106/src/cpp/server/ServerSessionManager.cpp#L126
+export SINGULARITYENV_RSTUDIO_SESSION_TIMEOUT=0
+
+export SINGULARITYENV_USER=$(id -un)
+export SINGULARITYENV_PASSWORD=$(openssl rand -base64 15)
 # get unused socket per https://unix.stackexchange.com/a/132524
 # tiny race condition between the python & singularity commands
 readonly PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
 cat 1>&2 <<END
 1. SSH tunnel from your workstation using the following command:
 
-   ssh -N -L 8787:${HOSTNAME}:${PORT} ${USER}@LOGIN-HOST
+   ssh -N -L 8787:${HOSTNAME}:${PORT} ${SINGULARITYENV_USER}@LOGIN-HOST
 
    and point your web browser to http://localhost:8787
 
 2. log in to RStudio Server using the following credentials:
 
-   user: ${USER}
-   password: ${PASSWORD}
+   user: ${SINGULARITYENV_USER}
+   password: ${SINGULARITYENV_PASSWORD}
 
 When done using RStudio Server, terminate the job by:
 
@@ -97,17 +124,13 @@ When done using RStudio Server, terminate the job by:
       scancel -f ${SLURM_JOB_ID}
 END
 
-# User-installed R packages go into their home directory
-if [ ! -e ${HOME}/.Renviron ]
-then
-  printf '\nNOTE: creating ~/.Renviron file\n\n'
-  echo 'R_LIBS_USER=~/R/%p-library/%v' >> ${HOME}/.Renviron
-fi
-
-# This example bind mounts the /project directory on the host into the Singularity container.
-# By default the only host file systems mounted within the container are $HOME, /tmp, /proc, /sys, and /dev.
-singularity exec --bind=/project rstudio.simg \
-    rserver --www-port ${PORT} --auth-none=0 --auth-pam-helper-path=pam-helper
+singularity exec --cleanenv rstudio_4.0.4.sif \
+    rserver --www-port ${PORT} \
+            --auth-none=0 \
+            --auth-pam-helper-path=pam-helper \
+            --auth-stay-signed-in-days=30 \
+            --auth-timeout-minutes=0 \
+            --rsession-path=/etc/rstudio/rsession.sh
 printf 'rserver exited' 1>&2
 ```
 


### PR DESCRIPTION
Here's a go at updating the Singulatiy guide for RStudio 1.4.x. I've tried to throw in a few additional seemingly-good practices as well.

* Pin rocker/rstudio tag, due to periodic breaking changes in RStudio releases.
* By default, RStudio 1.4.x creates an SQLite database in /var/lib/rstudio-server.
  The contents of the revocation-list file has been moved to this database.
  Credit: [fasrc/fas-on-demand-rstudio](https://github.com/fasrc/fas-ondemand-rstudio/blob/07116cdf20478486e918ddc5afa646decd3701e2/template/script.sh.erb#L56)
* Update docs to mention Remote Image Builder for extending rocker rstudio images (using Singularity definition files)
* Set R_LIBS_USER to rocker-specific directory via environment variable (defined in rsession) instead of writing to ~/.Renviron to avoid mixing personal libraries from rocker images & any R environment on the host (e.g., loaded via environment module)
* Securely create temporary directory for files/directories that will be bind-mounted in the container
* Use `singularity exec --cleanenv` to prevent environment variables set on the host---and there can be quite a few st in an HPC cluster environment environment---from interferring with environment variables in the container. Prefix environment variables that should be passed through with `SINGULARITYENV_`