### PR TITLE
Update Hugo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[context.deploy-preview.environment]
+  HUGO_VERSION = "0.89.4"
+
+[context.production.environment]
+  HUGO_VERSION = "0.89.4"


### PR DESCRIPTION
I misunderstood the mechanism by which the source code of this repository is deployed to the website in the last PR #25.
The files in the docs directory are not actually deployed.

Checking the version of hugo.

https://github.com/rocker-org/website/blob/ab636ccbfe54617f12bbe271cd59e5809c193d5d/docs/index.html#L7

In the website, it is still `0.54.0` (!)

![image](https://user-images.githubusercontent.com/50911393/144851255-e1b7953b-e593-49db-ab3e-81b6808a2324.png)

The version of hugo that is used to build the actual web page can be controlled with the `netlify.toml` file added in this PR. (If this doesn't work in the preview, this PR will need to be taken down.)
https://gohugo.io/hosting-and-deployment/hosting-on-netlify/