### PR TITLE
Re-add raw HTML

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,10 @@ relativeurls = true
 publishDir = "docs"
 ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
 
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
 
 [permalinks]
   post = "/:year/:month/:slug/"

--- a/docs/images/index.html
+++ b/docs/images/index.html
@@ -148,27 +148,100 @@
 		  	  <h2 class="title text-center">The Rocker Images: choosing a container</h2>
 	            <p>The rocker project provides a collection of containers suited for different needs. find a base image to extend or images with popular software and optimized libraries pre-installed. Get the latest version or a reproducibly fixed environment.</p>
 <h3 id="the-versioned-stack">The versioned stack</h3>
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
+<table class="table table-condensed table-striped">
+<thead>
+<tr>
+<th>image</th>
+<th>description</th>
+<th>metrics</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/r-ver">r-ver</a></td>
+<td>Specify R version in docker tag. Builds on <code>debian:stable</code></td>
+<td><a href="https://hub.docker.com/r/rocker/r-ver"><img src="https://img.shields.io/docker/pulls/rocker/r-ver.svg" alt="" /></a></td>
+</tr>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/rstudio">rstudio</a></td>
+<td>Adds rstudio</td>
+<td><a href="https://hub.docker.com/r/rocker/rstudio"><img src="https://img.shields.io/docker/pulls/rocker/rstudio.svg" alt="" /></a></td>
+</tr>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/tidyverse">tidyverse</a></td>
+<td>Adds tidyverse &amp; devtools</td>
+<td><a href="https://hub.docker.com/r/rocker/tidyverse"><img src="https://img.shields.io/docker/pulls/rocker/tidyverse.svg" alt="" /></a></td>
+</tr>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/verse">verse</a></td>
+<td>Adds tex &amp; publishing-related packages</td>
+<td><a href="https://hub.docker.com/r/rocker/verse"><img src="https://img.shields.io/docker/pulls/rocker/verse.svg" alt="" /></a></td>
+</tr>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/geospatial">geospatial</a></td>
+<td>Adds geospatial libraries</td>
+<td><a href="https://hub.docker.com/r/rocker/geospatial"><img src="https://img.shields.io/docker/pulls/rocker/geospatial.svg" alt="" /></a></td>
+</tr>
+</tbody>
+</table>
 <p>This stack builds on stable Debian releases (for versions &lt;= <code>3.6.3</code>) or Ubuntu LTS (for versions &gt;= <code>4.0.0</code>). Images in this stack accept a version tag specifying which version of R is desired, e.g. <code>rocker/rstudio:3.4.0</code> for R <code>3.4.0</code>.  Version-tagged images are designed to be stable, consistently providing the same versions of all software (R, R packages, system libraries) rather than the latest available (though Debian system libraries will still recieve any security patches.)  Omit the tag or specify <code>:latest</code> to always recieve the latest (nightly build) versions, or <code>:devel</code> for an image running on the current development (pre-release) version of R.  This is a linear stack, with each image extending the previous one.</p>
 <p>See <a href="https://github.com/rocker-org/rocker-versioned2">the rocker-versioned2 repository</a> for details.</p>
 <h3 id="the-base-stack">The base stack</h3>
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
+<table class="table table-condensed table-striped">
+<thead>
+<tr>
+<th>image</th>
+<th>description</th>
+<th>metrics</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://hub.docker.com/r/_/r-base">r-base</a></td>
+<td>Current R via apt-get with <code>debian:testing</code> &amp; <code>unstable</code> repos</td>
+<td><a href="https://hub.docker.com/r/library/r-base"><img src="https://img.shields.io/docker/pulls/library/r-base.svg" alt="" /></a></td>
+</tr>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/r-devel">r-devel</a></td>
+<td>R-devel added side-by-side onto r-base (using alias <code>RD</code>)</td>
+<td><a href="https://hub.docker.com/r/rocker/r-devel"><img src="https://img.shields.io/docker/pulls/rocker/r-devel.svg" alt="" /></a></td>
+</tr>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/drd">drd</a></td>
+<td>lighter r-devel, built not quite daily</td>
+<td><a href="https://hub.docker.com/r/rocker/drd"><img src="https://img.shields.io/docker/pulls/rocker/drd.svg" alt="" /></a></td>
+</tr>
+</tbody>
+</table>
 <p>This stack builds on <code>debian:testing</code> and <code>debian:unstable</code>.  This is a branched stack, with all other images extending <code>r-base</code>.  Use this stack if you want access to the latest versions of system libraries and compilers through <code>apt-get</code>.</p>
 <p>See <a href="https://github.com/rocker-org/rocker">the rocker repository</a> for details.</p>
 <h3 id="additional-images">Additional images</h3>
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
+<table  class="table table-condensed table-striped">
+<thead>
+<tr>
+<th>image</th>
+<th>description</th>
+<th>metrics</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/r-devel-san">r-devel-san</a></td>
+<td>as r-devel, but built with compiler sanitizers</td>
+<td><a href="https://hub.docker.com/r/rocker/r-devel-san"><img src="https://img.shields.io/docker/pulls/rocker/r-devel-san.svg" alt="" /></a></td>
+</tr>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/r-devel-ubsan-clang">r-devel-ubsan-clan</a></td>
+<td>Sanitizers, clang c compiler (instead of gcc)</td>
+<td><a href="https://hub.docker.com/r/rocker/r-devel-ubsan-clang"><img src="https://img.shields.io/docker/pulls/rocker/r-devel-ubsan-clang.svg" alt="" /></a></td>
+</tr>
+<tr>
+<td><a href="https://hub.docker.com/r/rocker/shiny">shiny</a></td>
+<td>shiny-server on r-ver</td>
+<td><a href="https://hub.docker.com/r/rocker/shiny"><img src="https://img.shields.io/docker/pulls/rocker/shiny.svg" alt="" /></a></td>
+</tr>
+</tbody>
+</table>
 
 	      </div>
       </div>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -53,7 +53,7 @@ RStudio without authentication If you are certain you are running in a secure en
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>/use/networking/</guid>
-      <description>httpsHTTPS Any RStudio instance on a remote server is accessed over an unencrypted http by default (though RStudio encrypts the password entered to log in through client-side javascript.) The easiest way to connect over a secure https connection is to use a reverse proxy server, such as Caddy. To establish an encrypted https connection, you must first have control of a registered domain name: https cannot be used when connecting directly to a given ip address.</description>
+      <description>https HTTPS Any RStudio instance on a remote server is accessed over an unencrypted http by default (though RStudio encrypts the password entered to log in through client-side javascript.) The easiest way to connect over a secure https connection is to use a reverse proxy server, such as Caddy. To establish an encrypted https connection, you must first have control of a registered domain name: https cannot be used when connecting directly to a given ip address.</description>
     </item>
     
     <item>
@@ -102,7 +102,7 @@ singularity pull docker://rocker/rstudio:4.0.4 If additional Debian (or other) s
       
       <guid>/images/</guid>
       <description>The rocker project provides a collection of containers suited for different needs. find a base image to extend or images with popular software and optimized libraries pre-installed. Get the latest version or a reproducibly fixed environment.
-The versioned stack This stack builds on stable Debian releases (for versions &amp;lt;= 3.6.3) or Ubuntu LTS (for versions &amp;gt;= 4.0.0). Images in this stack accept a version tag specifying which version of R is desired, e.</description>
+The versioned stack   image description metrics     r-ver Specify R version in docker tag. Builds on debian:stable    rstudio Adds rstudio    tidyverse Adds tidyverse &amp;amp; devtools    verse Adds tex &amp;amp; publishing-related packages    geospatial Adds geospatial libraries     This stack builds on stable Debian releases (for versions &amp;lt;= 3.</description>
     </item>
     
   </channel>

--- a/docs/use/index.xml
+++ b/docs/use/index.xml
@@ -43,7 +43,7 @@ RStudio without authentication If you are certain you are running in a secure en
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>/use/networking/</guid>
-      <description>httpsHTTPS Any RStudio instance on a remote server is accessed over an unencrypted http by default (though RStudio encrypts the password entered to log in through client-side javascript.) The easiest way to connect over a secure https connection is to use a reverse proxy server, such as Caddy. To establish an encrypted https connection, you must first have control of a registered domain name: https cannot be used when connecting directly to a given ip address.</description>
+      <description>https HTTPS Any RStudio instance on a remote server is accessed over an unencrypted http by default (though RStudio encrypts the password entered to log in through client-side javascript.) The easiest way to connect over a secure https connection is to use a reverse proxy server, such as Caddy. To establish an encrypted https connection, you must first have control of a registered domain name: https cannot be used when connecting directly to a given ip address.</description>
     </item>
     
     <item>

--- a/docs/use/networking/index.html
+++ b/docs/use/networking/index.html
@@ -146,7 +146,7 @@
 			<div class="container">
 		  	<div class="section text-left">
 		  	  <h2 class="title text-center">Networking: tips and tricks</h2>
-	            <h3 id="i-classmaterial-iconshttpsi-https"><!-- raw HTML omitted -->https<!-- raw HTML omitted --> HTTPS</h3>
+	            <h3 id="i-classmaterial-iconshttpsi-https"><i class="material-icons">https</i> HTTPS</h3>
 <p>Any RStudio instance on a remote server is accessed over an unencrypted http by default (though RStudio encrypts the password entered to log in through client-side javascript.)  The easiest way to connect over a secure https connection is to use a reverse proxy server, such as <a href="https://caddyserver.com">Caddy</a>.  To establish an encrypted https connection, you must first have control of a registered domain name: https cannot be used when connecting directly to a given ip address. Once you have pointed your domain name at the ip address of the server, Caddy provides a quick way to get set up with https using LetsEncrypt certificates.  Below is an example <code>Caddyfile</code> specifying the necessary configuration, along with a <code>docker-compose</code> file which sets up an RStudio server instance behind a separate container running <code>caddy</code>.  This approach also makes it easy to map ports to subdomains for cleaner-looking URLs:</p>
 <p>Example <code>site/Caddyfile</code>:</p>
 <pre tabindex="0"><code>rstudio.example.com {
@@ -180,8 +180,8 @@
       - <span style="color:#ae81ff">$HOME/students:/home/</span>
     <span style="color:#f92672">restart</span>: <span style="color:#ae81ff">always</span>
 </code></pre></div><p>More details about the use of <a href="https://docs.docker.com/compose/">docker-compose</a> and <a href="https://caddyserver.com/">Caddy Server</a> are found on their websites.</p>
-<h3 id="i-classmaterial-iconsdata_usagei-monitoring"><!-- raw HTML omitted -->data_usage<!-- raw HTML omitted --> Monitoring</h3>
-<h3 id="i-classfa-fa-databasei-linking-database-containers"><!-- raw HTML omitted --><!-- raw HTML omitted --> Linking database containers</h3>
+<h3 id="i-classmaterial-iconsdata_usagei-monitoring"><i class="material-icons">data_usage</i> Monitoring</h3>
+<h3 id="i-classfa-fa-databasei-linking-database-containers"><i class="fa fa-database"></i> Linking database containers</h3>
 
 	      </div>
       </div>

--- a/docs/use/other_topics/index.html
+++ b/docs/use/other_topics/index.html
@@ -171,7 +171,12 @@ update-alternatives --set libblas.so.3 /usr/lib/openblas-base/libblas.so.3
 <pre tabindex="0"><code># run R with the libblas
 docker run -ti -e LD_LIBRARY_PATH=/usr/lib/libblas rocker/r-ver
 </code></pre><h3 id="x11">X11</h3>
-<!-- raw HTML omitted -->
+<div class="alert alert-warning"><div class="container-fluid"><div class="alert-icon">
+<i class="material-icons">info_outline</i></div>
+<button type="button" class="close" data-dismiss="alert" aria-label="Close">
+<span aria-hidden="true"><i class="material-icons">clear</i></span></button>
+Coming soon...
+</div></div>
 <h2 id="singularityusesingularity"><a href="../../use/singularity">Singularity</a></h2>
 <p>See <a href="../../use/singularity">Singularity</a> for use in HPC environments without Docker installed.</p>
 


### PR DESCRIPTION
Add a setting to config.toml to prevent the html tags from being removed.
(Or, #26 did not solve the issue #23, so please revert #26 and close this PR)

I missed the fact that html tags are removed when building with hugo 0.60.0 or later, as explained here https://github.com/rocker-org/website/pull/26#issuecomment-987966043.

The images page now

![image](https://user-images.githubusercontent.com/50911393/145048809-32c95945-7269-464e-b883-52f061887fd9.png)

source

![image](https://user-images.githubusercontent.com/50911393/145049258-edb949b2-c8f8-4913-b5cb-a16ff8c35a3e.png)

I think the table should really be rewritten in markdown notation, but my knowledge did not allow me to replace them with markdown notation while maintaining their appearance, so I left them as html tags.
