### PR TITLE
Add links to Rocker papers

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,6 +57,11 @@ with significant contributions from a broad community of users and developers.
 Get in touch on [GitHub issues](https://github.com/rocker-org/rocker/issues) with bug reports,
 feature requests, or other feedback.
 
+## 📜Papers
+
+- [An Introduction to Rocker: Docker Containers for R](https://doi.org/10.32614/RJ-2017-065)
+- [The Rockerverse: Packages and Applications for Containerisation with R](https://doi.org/10.32614/RJ-2020-007)
+
 ## ⚖️License
 
 The Rocker Dockerfiles are licensed under the GPL 2 or later.


### PR DESCRIPTION
Suggested by https://github.com/rocker-org/website/pull/51#issuecomment-1166800400

For now, only the titles of the papers are shown, but this can be changed if other notations are considered better.