### PR TITLE
Add new pages for Dev Container (Features / Images / Templates)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,10 +6,6 @@ charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = true
 
-[*.md]
-indent_style = space
-indent_size = 4
-
 [*.json]
 indent_style = tab
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -55,8 +55,6 @@ website:
         - text: ---
         - section: Dev Container
           contents:
-            - text: Overview
-              href: images/devcontainer/index.md
             - text: Features
               href: images/devcontainer/features.md
             - text: Images

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -53,6 +53,17 @@ website:
             - text: r-bspm
               href: images/other/r-bspm.md
         - text: ---
+        - section: Dev Container
+          contents:
+            - text: Overview
+              href: images/devcontainer/index.md
+            - text: Features
+              href: images/devcontainer/features.md
+            - text: Images
+              href: images/devcontainer/images.md
+            - text: Temlates
+              href: images/devcontainer/templates.md
+        - text: ---
         - section: Other projects
           contents:
             - text: External images and tools for R

--- a/images/devcontainer/features.md
+++ b/images/devcontainer/features.md
@@ -60,3 +60,8 @@ Some tips for choosing:
   you can use `r-rig` to install any version of R or only the R package without installing R.
 - If you want to install packages that exist in the conda-forge,
   you can use `miniforge` for fast installation with `mamba`.
+
+## See also
+
+- [Dev Container Images](images.md)
+- [Dev Container Templates](templates.md)

--- a/images/devcontainer/features.md
+++ b/images/devcontainer/features.md
@@ -17,7 +17,8 @@ These can be used to easily configure R on containers without R installed,
 or to make containers for R even more useful.
 And of course, we can use them independently of R! (except for the Features to install R)
 
-For example, install R on the default image of Codespaces by editing the `devcontainer.json` file as follows:
+For example, install R on the default image of Codespaces
+by editing [the `devcontainer.json` file](https://containers.dev/implementors/spec/#devcontainerjson) as follows:
 
 ```{.json filename=".devcontainer/devcontainer.json"}
 {

--- a/images/devcontainer/features.md
+++ b/images/devcontainer/features.md
@@ -4,7 +4,8 @@ title: Dev Container Features
 
 ## Overview
 
-The Rocker Project provides some Dev Container Features for installing R or installing software often used with R.
+The Rocker Project provides some [Dev Container Features](https://containers.dev/implementors/features/)
+for installing R or installing software often used with R.
 
 - Source repository: [rocker-org/devcontainer-features](https://github.com/rocker-org/devcontainer-features)
 

--- a/images/devcontainer/features.md
+++ b/images/devcontainer/features.md
@@ -42,11 +42,12 @@ Check the source repository for details on each Feature.
 Each of these installations of R will be configured to allow installation of R binary packages in the following ways.
 
 1. [System package management system (`apt`)](../../use/extending.md#system-package-management-system)
-2. [RStudio Public Package Manager (R functions e.g. `install.packages`)](../../use/extending.md#rstudio-public-package-manager)[^rspm]
+2. [Posit Public Package Manager (R functions e.g. `install.packages`)](../../use/extending.md#rstudio-public-package-manager)[^rspm]
 3. [conda-forge (`mamba` or `conda`)](../../use/extending.md#conda-forge)
 
 [^rspm]: Of the amd64 and arm64 Debian and Ubuntu platforms that can use `r-rig`,
-only amd64 Ubuntu can use RSPM, and RSPM is not configured on the other platforms.
+only amd64 Ubuntu can use Posit Public Package Manager,
+and Posit Public Package Manager will be not configured on the other platforms.
 
 Therefore, which of these you use to install R
 may depend on which method you wish to use to install the R binary packages.

--- a/images/devcontainer/features.md
+++ b/images/devcontainer/features.md
@@ -54,7 +54,7 @@ may depend on which method you wish to use to install the R binary packages.
 
 Some tips for choosing:
 
-- When installing R packages via `apt` or `mamba` (`conda`), dependencies are installed automatically.
+- When installing R packages via `apt` or `mamba` (`conda`), dependencies outside of R are installed automatically.
   But, installing R packages via R function (`install.packages`)
   may require separate `apt` installations of system libraries that are dependencies.
 - Generally `r-apt` installs R packages faster than `r-rig`.

--- a/images/devcontainer/features.md
+++ b/images/devcontainer/features.md
@@ -6,9 +6,17 @@ title: Dev Container Features
 
 The Rocker Project provides some Dev Container Features for installing R or installing software often used with R.
 
+- Source repository: [rocker-org/devcontainer-features](https://github.com/rocker-org/devcontainer-features)
+
+You can find them on the [Dev Containers site](https://containers.dev/collections),
+[the GitHub Codespaces Dev Container Editor](https://github.blog/changelog/2022-10-21-codespaces-configuration-with-the-dev-container-editor/),
+or, [VSCode Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers).
+
 These can be used to easily configure R on containers without R installed,
 or to make containers for R even more useful.
 And of course, we can use them independently of R! (except for the Features to install R)
+
+For example, install R on the default image of Codespaces by editing the `devcontainer.json` file as follows:
 
 ```{.json filename=".devcontainer/devcontainer.json"}
 {
@@ -18,6 +26,8 @@ And of course, we can use them independently of R! (except for the Features to i
     }
 }
 ```
+
+Check the source repository for details on each Feature.
 
 ## Install R on Dev Containers
 
@@ -29,9 +39,23 @@ And of course, we can use them independently of R! (except for the Features to i
 
 Each of these installations of R will be configured to allow installation of R binary packages in the following ways.
 
-1. [System package management system](../../use/extending.md#system-package-management-system)
-2. [RStudio Public Package Manager](../../use/extending.md#rstudio-public-package-manager)[^rspm]
-3. [conda-forge](../../use/extending.md#conda-forge)
+1. [System package management system (`apt`)](../../use/extending.md#system-package-management-system)
+2. [RStudio Public Package Manager (R functions e.g. `install.packages`)](../../use/extending.md#rstudio-public-package-manager)[^rspm]
+3. [conda-forge (`mamba` or `conda`)](../../use/extending.md#conda-forge)
 
 [^rspm]: Of the amd64 and arm64 Debian and Ubuntu platforms that can use `r-rig`,
 only amd64 Ubuntu can use RSPM, and RSPM is not configured on the other platforms.
+
+Therefore, which of these you use to install R
+may depend on which method you wish to use to install the R binary packages.
+
+Some tips for choosing:
+
+- Generally `r-apt` installs R packages faster than `r-rig`.
+  Therefore, if you want to add R to a container, we recommend trying `r-apt` first.
+  However, `r-apt` does not support `ubuntu` on arm64 platform, so if you want to use `ubuntu` on arm64 platform,
+  use `r-rig` instead.
+- If you want to install any version of R or use R already installed in the container,
+  you can use `r-rig` to install any version of R or only the R package without installing R.
+- If you want to install packages that exist in the conda-forge,
+  you can use `miniforge` for fast installation with `mamba`.

--- a/images/devcontainer/features.md
+++ b/images/devcontainer/features.md
@@ -53,6 +53,9 @@ may depend on which method you wish to use to install the R binary packages.
 
 Some tips for choosing:
 
+- When installing R packages via `apt` or `mamba` (`conda`), dependencies are installed automatically.
+  But, installing R packages via R function (`install.packages`)
+  may require separate `apt` installations of system libraries that are dependencies.
 - Generally `r-apt` installs R packages faster than `r-rig`.
   Therefore, if you want to add R to a container, we recommend trying `r-apt` first.
   However, `r-apt` does not support `ubuntu` on arm64 platform, so if you want to use `ubuntu` on arm64 platform,

--- a/images/devcontainer/features.md
+++ b/images/devcontainer/features.md
@@ -1,0 +1,37 @@
+---
+title: Dev Container Features
+---
+
+## Overview
+
+The Rocker Project provides some Dev Container Features for installing R or installing software often used with R.
+
+These can be used to easily configure R on containers without R installed,
+or to make containers for R even more useful.
+And of course, we can use them independently of R! (except for the Features to install R)
+
+```{.json filename=".devcontainer/devcontainer.json"}
+{
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "features": {
+        "ghcr.io/rocker-org/devcontainer-features/r-apt:latest": {}
+    }
+}
+```
+
+## Install R on Dev Containers
+
+1. [`r-apt`](https://github.com/rocker-org/devcontainer-features/tree/main/src/r-apt)
+2. [`r-rig`](https://github.com/rocker-org/devcontainer-features/tree/main/src/r-rig)
+3. [`miniforge`](https://github.com/rocker-org/devcontainer-features/tree/main/src/miniforge)[^miniforge]
+
+[^miniforge]: This Feature does not directly install R, but it configures mamba so we can use mamba to install R.
+
+Each of these installations of R will be configured to allow installation of R binary packages in the following ways.
+
+1. [System package management system](../../use/extending.md#system-package-management-system)
+2. [RStudio Public Package Manager](../../use/extending.md#rstudio-public-package-manager)[^rspm]
+3. [conda-forge](../../use/extending.md#conda-forge)
+
+[^rspm]: Of the amd64 and arm64 Debian and Ubuntu platforms that can use `r-rig`,
+only amd64 Ubuntu can use RSPM, and RSPM is not configured on the other platforms.

--- a/images/devcontainer/images.md
+++ b/images/devcontainer/images.md
@@ -46,6 +46,10 @@ Or, we can use it as a base image in a Dockerfile.
 FROM ghcr.io/rocker-org/devcontainer/tidyverse:4
 ```
 
+To install the R package on the Dockerfile, please refer to [the Extending images page](../../use/extending.md).
+
+When used with a Dockerfile, the `devcontainer.json` file must be rewritten to refer to the Dockerfile.
+
 ```{.json filename=".devcontainer/devcontainer.json"}
 {
     "name": "${localWorkspaceFolderBasename}",

--- a/images/devcontainer/images.md
+++ b/images/devcontainer/images.md
@@ -2,6 +2,8 @@
 title: Pre-built Dev Container Images
 ---
 
+- Source repository: [rocker-org/devcontainer-images](https://github.com/rocker-org/devcontainer-images)
+
 ## Overview
 
 ```{.json filename=".devcontainer/devcontainer.json"}

--- a/images/devcontainer/images.md
+++ b/images/devcontainer/images.md
@@ -2,12 +2,78 @@
 title: Pre-built Dev Container Images
 ---
 
+## Quick reference
+
 - Source repository: [rocker-org/devcontainer-images](https://github.com/rocker-org/devcontainer-images)
+- Source
+  - [r-ver](https://github.com/rocker-org/devcontainer-images/tree/main/src/r-ver)
+  - [tidyverse, geospatial](https://github.com/rocker-org/devcontainer-images/tree/main/src/rstudio)
+- tags
+  - [r-ver](https://github.com/rocker-org/devcontainer-images/pkgs/container/devcontainer%2Fr-ver)
+  - [tidyverse](https://github.com/rocker-org/devcontainer-images/pkgs/container/devcontainer%2Ftidyverse)
+  - [geospatial](https://github.com/rocker-org/devcontainer-images/pkgs/container/devcontainer%2Fgeospatial)
+- Published image details: not available
+- Non-root default user: `rstudio`
 
 ## Overview
 
+The Rocker Project provides some Docker container images which built with Dev Container Features.
+Packages commonly used for development are already installed.
+
+These images are intended to be images for R that can be used like the Dev Container images
+built from [`devcontainers/images`](https://github.com/devcontainers/images) for each language.
+
+`ghcr.io/rocker-org/devcontainer/r-ver`, `ghcr.io/rocker-org/devcontainer/tidyverse`,
+and `ghcr.io/rocker-org/devcontainer/geospatial` are correspond to [`rocker/r-ver`](r-ver.md),
+[`rocker/tidyverse`, and `rocker/geospatial`](rstudio.md), respectively.
+
+## How to use
+
+### devcontainer.json
+
+Specify the image in `devcontainer.json` as follows.
+
 ```{.json filename=".devcontainer/devcontainer.json"}
 {
+    "name": "${localWorkspaceFolderBasename}",
     "image": "ghcr.io/rocker-org/devcontainer/r-ver:4"
 }
 ```
+
+Or, we can use it as a base image in a Dockerfile.
+
+```{.dockerfile filename=".devcontainer/Dockerfile"}
+FROM ghcr.io/rocker-org/devcontainer/tidyverse:4
+```
+
+```{.json filename=".devcontainer/devcontainer.json"}
+{
+    "name": "${localWorkspaceFolderBasename}",
+    "build": {
+        "dockerfile": "Dockerfile"
+    }
+}
+```
+
+### Command line
+
+We can use [radian](https://github.com/randy3k/radian) instead of the default R console.
+
+```{.sh filename="Terminal"}
+docker run --rm -ti ghcr.io/rocker-org/devcontainer/r-ver:4 radian
+```
+
+Also [`httpgd`](https://nx10.github.io/httpgd/) is already installed
+so we can expose the container port to show the plot in the browser.
+See [the GUI page](../../use/gui.md) for details.
+
+### RStudio Server
+
+`ghcr.io/rocker-org/devcontainer/tidyverse` and `ghcr.io/rocker-org/devcontainer/geospatial`
+have already installed RStudio Server.
+See [the `rocker/rstudio` reference page](../versioned/rstudio.md) for usage.
+
+## See also
+
+- [Dev Container Features](features.md)
+- [Dev Container Templates](templates.md)

--- a/images/devcontainer/images.md
+++ b/images/devcontainer/images.md
@@ -1,0 +1,11 @@
+---
+title: Pre-built Dev Container Images
+---
+
+## Overview
+
+```{.json filename=".devcontainer/devcontainer.json"}
+{
+    "image": "ghcr.io/rocker-org/devcontainer/r-ver:4"
+}
+```

--- a/images/devcontainer/images.md
+++ b/images/devcontainer/images.md
@@ -31,7 +31,7 @@ and `ghcr.io/rocker-org/devcontainer/geospatial` are correspond to [`rocker/r-ve
 
 ### devcontainer.json
 
-Specify the image in `devcontainer.json` as follows.
+Specify the image in [`devcontainer.json`](https://containers.dev/implementors/spec/#devcontainerjson) as follows.
 
 ```{.json filename=".devcontainer/devcontainer.json"}
 {
@@ -54,6 +54,8 @@ FROM ghcr.io/rocker-org/devcontainer/tidyverse:4
     }
 }
 ```
+
+[The Dev Container Templates provided by the Rocker Project](templates.md) include `devcontainer.json` like these.
 
 ### Command line
 

--- a/images/devcontainer/index.md
+++ b/images/devcontainer/index.md
@@ -1,0 +1,6 @@
+---
+title: Development Container
+---
+
+You can also find them on the [Dev Containers site](https://containers.dev/collections),
+GitHub Codespaces Dev Container Editor, or, VSCode Dev Containers.

--- a/images/devcontainer/index.md
+++ b/images/devcontainer/index.md
@@ -1,9 +1,9 @@
 ---
 title: Development Container Resources
 listing:
-    type: grid
-    sort: title
-    fields:
-        - title
-        - description
+  type: grid
+  sort: title
+  fields:
+    - title
+    - description
 ---

--- a/images/devcontainer/index.md
+++ b/images/devcontainer/index.md
@@ -1,6 +1,9 @@
 ---
-title: Development Container
+title: Development Container Resources
+listing:
+  type: grid
+  sort: title
+  fields:
+    - title
+    - description
 ---
-
-You can also find them on the [Dev Containers site](https://containers.dev/collections),
-GitHub Codespaces Dev Container Editor, or, VSCode Dev Containers.

--- a/images/devcontainer/index.md
+++ b/images/devcontainer/index.md
@@ -1,9 +1,9 @@
 ---
 title: Development Container Resources
 listing:
-  type: grid
-  sort: title
-  fields:
-    - title
-    - description
+    type: grid
+    sort: title
+    fields:
+        - title
+        - description
 ---

--- a/images/devcontainer/templates.md
+++ b/images/devcontainer/templates.md
@@ -1,0 +1,10 @@
+---
+title: Dev Container Templates
+---
+
+For example, the following command creates `.devcontainer` directory
+from the [Template](https://github.com/rocker-org/devcontainer-templates/tree/main/src/r-ver).
+
+```{.sh filename="Terminal"}
+devcontainer templates apply -t ghcr.io/rocker-org/devcontainer-templates/r-ver
+```

--- a/images/devcontainer/templates.md
+++ b/images/devcontainer/templates.md
@@ -2,11 +2,22 @@
 title: Dev Container Templates
 ---
 
+## Overview
+
+The Rocker Project provides some [Dev Container Templates](https://containers.dev/implementors/templates/)
+for building an R development environment.
+
 - Source repository: [rocker-org/devcontainer-templates](https://github.com/rocker-org/devcontainer-templates)
 
-For example, the following command creates `.devcontainer` directory
-from the [Template](https://github.com/rocker-org/devcontainer-templates/tree/main/src/r-ver).
+These are displayed on the GitHub Codespaces or on the VS Code Dev Containers UI.
+
+These can also be use from [the devcontainer CLI](https://github.com/devcontainers/cli).
 
 ```{.sh filename="Terminal"}
 devcontainer templates apply -t ghcr.io/rocker-org/devcontainer-templates/r-ver
 ```
+
+## See also
+
+- [Dev Container Features](features.md)
+- [Dev Container Images](images.md)

--- a/images/devcontainer/templates.md
+++ b/images/devcontainer/templates.md
@@ -2,6 +2,8 @@
 title: Dev Container Templates
 ---
 
+- Source repository: [rocker-org/devcontainer-templates](https://github.com/rocker-org/devcontainer-templates)
+
 For example, the following command creates `.devcontainer` directory
 from the [Template](https://github.com/rocker-org/devcontainer-templates/tree/main/src/r-ver).
 

--- a/images/index.md
+++ b/images/index.md
@@ -62,3 +62,8 @@ but with different build tools.
 |----------------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
 | [`rocker/r-ubuntu`](other/r-ubuntu.md) | `ubuntu`                                                                  | Close to `r-base`, but based on `ubuntu`                                                                          | ![Docker Pulls](https://img.shields.io/docker/pulls/rocker/r-ubuntu.svg) |
 | [`rocker/r-bspm`](other/r-bspm.md)     | `r-base`, `rocker/r-ubuntu`, `archlinux`, `fedora`, `opensuse/tumbleweed` | Binary installation of R packages has been configured, powered by [bspm](https://cran.r-project.org/package=bspm) | ![Docker Pulls](https://img.shields.io/docker/pulls/rocker/r-bspm.svg)   |
+
+### Dev Container Images
+
+Images built by [the devcontainer CLI](https://github.com/devcontainers/cli).
+See [the Dev Container Images page](devcontainer/images.md) for details.

--- a/use/editor.md
+++ b/use/editor.md
@@ -80,6 +80,12 @@ and also installs [`radian`](https://github.com/randy3k/radian) as R console.
 
 This definition can also be used in [GitHub Codespaces](https://github.com/features/codespaces).
 
+See also
+
+- [Dev Container Templates](../images/devcontainer/templates.md)
+- [Dev Container Images](../images/devcontainer/images.md)
+- [Dev Container Features](../images/devcontainer/features.md)
+
 ### coder/code-server and gitpod-io/openvscode-server
 
 Both [coder's code-server](https://github.com/coder/code-server) and


### PR DESCRIPTION
close #77
related to rocker-org/devcontainer-features#74
related to rocker-org/devcontainer-templates#3

By the way, I tried to do all this PR work in Codespaces (transfer to VSCode on my local computer).
I had no problems at all working while doing quarto preview, which convinced me that this will be widely used in the future.