### PR TITLE
Add note about using `devtools::check()` on `rocker/r-ver`

### DIFF
--- a/images/versioned/r-ver.md
+++ b/images/versioned/r-ver.md
@@ -75,6 +75,18 @@ FROM rocker/r-ver:4
 RUN echo 'options(repos = c(CRAN = "https://cloud.r-project.org"))' >>"${R_HOME}/etc/Rprofile.site"
 ```
 
+Or, if you want to temporarily change the CRAN mirror during an R session, use the `options()` function.
+
+A common use case is when developing an R package and using the `devtools::check()` function;
+if the CRAN mirror is not changed from the default, an error like
+`cannot open URL 'packagemanager.posit.co/cran/__linux__/jammy/latest/web/packages/packages.rds': HTTP status was '404 Not Found'`
+may occur.
+
+```r
+options(repos = c(CRAN = "https://cloud.r-project.org"))
+devtools::check()
+```
+
 ### Selecting the BLAS implementation used by R
 
 By default `rocker/r-ver` uses [the OpenBLAS](https://www.openblas.net/) implementation for Linear Algebra[^blas].

--- a/images/versioned/r-ver.md
+++ b/images/versioned/r-ver.md
@@ -31,7 +31,8 @@ Compared to `r-base`,
   (the `r-base` stack gets the latest R version as a binary from Debian unstable).
 - The only platforms available are `linux/amd64` and `linux/arm64`
   (arm64 images are experimental and only available for `rocker/r-ver` 4.1.0 or later).
-- Set [the RStudio Public Package Manager (RSPM)](https://packagemanager.rstudio.com) as default CRAN mirror.
+- Set [the Posit Public Package Manager (RStudio Package Manager, RSPM)](https://packagemanager.rstudio.com)
+  as default CRAN mirror.
   For the amd64 platform, RSPM serves compiled Linux binaries of R packages and greatly speeds up package installs.
 - Non-latest R version images installs all R packages from a fixed snapshot of CRAN mirror at a given date.
   This setting ensures that the same version of the R package is installed no matter when the installation is performed.

--- a/images/versioned/r-ver.md
+++ b/images/versioned/r-ver.md
@@ -71,7 +71,7 @@ To use a different CRAN mirror, simply write a new setting in the `Rprofile`.
 
 For example, the following Dockerfile sets the default repository to CRAN.
 
-```dockerfile
+```{.dockerfile filename="Dockerfile"}
 FROM rocker/r-ver:4
 RUN echo 'options(repos = c(CRAN = "https://cloud.r-project.org"))' >>"${R_HOME}/etc/Rprofile.site"
 ```
@@ -83,7 +83,7 @@ if the CRAN mirror is not changed from the default, an error like
 `cannot open URL 'packagemanager.posit.co/cran/__linux__/jammy/latest/web/packages/packages.rds': HTTP status was '404 Not Found'`
 may occur.
 
-```r
+```{.r filename="R Terminal"}
 options(repos = c(CRAN = "https://cloud.r-project.org"))
 devtools::check()
 ```
@@ -112,7 +112,7 @@ If this error occurs, change the BLAS used by R to libblas as described below.
 
 You can see the current BLAS configuration for R by using `sessionInfo()` function in R console.
 
-```r
+```{.r filename="R Terminal"}
 sessionInfo()
 #> R version 4.2.0 (2022-04-22)
 #> Platform: x86_64-pc-linux-gnu (64-bit)
@@ -133,7 +133,7 @@ You can switch BLAS used by R with the Debian `update-alternatives` script:
 
 ##### Switch to libblas
 
-```bash
+```{.bash filename="Terminal"}
 ARCH=$(uname -m)
 update-alternatives --set "libblas.so.3-${ARCH}-linux-gnu" "/usr/lib/${ARCH}-linux-gnu/blas/libblas.so.3"
 update-alternatives --set "liblapack.so.3-${ARCH}-linux-gnu" "/usr/lib/${ARCH}-linux-gnu/lapack/liblapack.so.3"
@@ -141,7 +141,7 @@ update-alternatives --set "liblapack.so.3-${ARCH}-linux-gnu" "/usr/lib/${ARCH}-l
 
 ##### Switch to openblas
 
-```bash
+```{.bash filename="Terminal"}
 ARCH=$(uname -m)
 update-alternatives --set "libblas.so.3-${ARCH}-linux-gnu" "/usr/lib/${ARCH}-linux-gnu/openblas-pthread/libblas.so.3"
 update-alternatives --set "liblapack.so.3-${ARCH}-linux-gnu" "/usr/lib/${ARCH}-linux-gnu/openblas-pthread/liblapack.so.3"

--- a/use/extending.md
+++ b/use/extending.md
@@ -89,16 +89,16 @@ Check [the `pak` package documentation](https://pak.r-lib.org/index.html) for de
 Source installations generally take longer than binary installations,
 so there are several ways to install binary R packages on Linux.
 
-#### [RStudio Public Package Manager](https://packagemanager.rstudio.com/)
+#### [Posit Public Package Manager](https://packagemanager.rstudio.com/)
 
-RStudio Package Manager (RSPM) provides binary R packages for specific Linux distributions[^rspm].
+Posit Package Manager (Formerly "RStudio Package Manager", RSPM) provides binary R packages for specific Linux distributions[^rspm].
 Since RSPM provides all packages on CRAN as a CRAN mirror,
 users can install packages just as if they were installed from CRAN.
 
-[^rspm]: [RStudio Package Manager: Admin Guide](https://docs.rstudio.com/rspm/admin/serving-binaries/#supported-operating-systems)
+[^rspm]: [Posit Package Manager: Admin Guide](https://docs.posit.co/rspm/admin/serving-binaries/#supported-operating-systems)
 
 For example, Ubuntu based image [`rocker/r-ver:4`](../images/versioned/r-ver.md) on amd64 platform,
-which has already set up the public version of RSPM (RStudio Public Package Manager) as its default CRAN mirror,
+which has already set up the public version of RSPM (Posit Public Package Manager) as its default CRAN mirror,
 can install the `curl` package as follows.
 
 ```dockerfile
@@ -112,7 +112,7 @@ Some packages (e.g. [`sf`](https://CRAN.R-project.org/package=sf))
 will fail to load if the system requirements are not met when the package is attempted to be loaded.
 In such cases, the system libraries must be installed as in the case of source installation.
 
-Please check [frequently asked questions for RStudio Public Package Manager](https://support.rstudio.com/hc/en-us/articles/360046703913).
+Please check [FAQ for Posit Public Package Manager](https://support.posit.co/hc/en-us/articles/360046703913).
 
 :::
 


### PR DESCRIPTION
Addresses rocker-org/rocker-versioned2#532 and rocker-org/devcontainer-features#156
Indicate that `devtools::check()` will fail if CRAN is not changed.

Related to this, reflecting the renaming of the RStudio Package Manager.