### PR TITLE
Update singularity.md

### DIFF
--- a/use/singularity.md
+++ b/use/singularity.md
@@ -46,7 +46,7 @@ To enable password authentication, set the PASSWORD environment variable and add
 PASSWORD='...' singularity exec \
    --bind run:/run,var-lib-rstudio-server:/var/lib/rstudio-server,database.conf:/etc/rstudio/database.conf \
    rstudio_4.2.sif \
-   /usr/lib/rstudio-server/bin/rserver --auth-none=0 --auth-pam-helper-path=pam-helper
+   /usr/lib/rstudio-server/bin/rserver --auth-none=0 --auth-pam-helper-path=pam-helper --server-user=$(whoami)
 ```
 
 After pointing your browser to http://_hostname_:8787, enter your local user ID on the system as the username, and the custom password specified in the PASSWORD environment variable.


### PR DESCRIPTION
without `--server-user=$(whoami)` latest RStudio Server will not start in Singularity/Apptainer container with error `[rserver] ERROR Attempt to run server as user 'rstudio-server' (uid 999) from account 'user_account' (uid 1001) without privilege, which is required to run as a different uid`