### PR TITLE
Summarize rootless instructions

### DIFF
--- a/use/rootless-podman.md
+++ b/use/rootless-podman.md
@@ -1,5 +1,5 @@
 ---
-title: "Running Rootless"
+title: "Running without root privileges using Podman"
 description: Rootless containers and rocker
 ---
 

--- a/use/rootless-podman.md
+++ b/use/rootless-podman.md
@@ -1,6 +1,8 @@
 ---
 title: "Running without root privileges using Podman"
 description: Rootless containers and rocker
+aliases:
+  - /use/rootless.html
 ---
 
 Docker traditionally ran as the `root` user. Users who wanted to run docker

--- a/use/rootless.md
+++ b/use/rootless.md
@@ -37,7 +37,7 @@ as root. **For most rocker-related projects, running rootless is a security adva
 
 At the host:
 
-```{.sh}
+```{.sh filename="Terminal"}
 whoami
 # sergio
 ```
@@ -45,7 +45,7 @@ whoami
 In the container:
 
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run --rm docker.io/rocker/rstudio whoami
 # root
 ```
@@ -57,7 +57,7 @@ rootless container, because it just modifies files inside the container.
 
 At the host:
 
-```{.sh}
+```{.sh filename="Terminal"}
 apt-get update
 # Reading package lists... Done
 # E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
@@ -65,7 +65,7 @@ apt-get update
 
 In the container:
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run --rm docker.io/rocker/rstudio apt-get update
 # Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
 # ...
@@ -81,14 +81,14 @@ when you are outside the container.
 
 At the host:
 
-```{.sh}
+```{.sh filename="Terminal"}
 touch /etc/try-creating-a-file
 # touch: cannot touch '/etc/try-creating-a-file': Permission denied
 ```
 
 In the container: *Rootless means no additional host permissions*
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run --rm -v /etc/:/hostetc docker.io/rocker/rstudio \
   touch /hostetc/try-creating-a-file
 # touch: cannot touch '/hostetc/try-creating-a-file': Permission denied
@@ -96,14 +96,14 @@ podman run --rm -v /etc/:/hostetc docker.io/rocker/rstudio \
 
 However, you can modify the files *within* the container:
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run --rm docker.io/rocker/rstudio touch /etc/try-creating-a-file
 ```
 
 And files from mounted volumes, assuming you have the permissions where they
 are mounted at the host:
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run \
     --rm \
     --volume "$HOME/workdir:/workdir" \
@@ -121,7 +121,7 @@ since those are reserved to root (or to be precise reserved to processes with
 `CAP_NET_BIND_SERVICE` capability set).
 
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run --rm -p 80:8787 docker.io/rocker/rstudio
 # Error: rootlessport cannot expose privileged port 80, you can add 
 # 'net.ipv4.ip_unprivileged_port_start=80' to /etc/sysctl.conf (currently 1024),
@@ -131,7 +131,7 @@ podman run --rm -p 80:8787 docker.io/rocker/rstudio
 
 However larger port numbers work perfectly fine:
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run --rm -p 8787:8787 docker.io/rocker/rstudio
 ```
 
@@ -150,7 +150,7 @@ you won't be able to access that directory if you try to login from RStudio's we
 browser. It will only work from process launched from the command line.
 
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run 
   -ti \
   --rm \
@@ -164,7 +164,7 @@ podman run
 
 1. Find out the group ID (GID) of the `rfriends` group.
 
-    ```{.sh}
+    ```{.sh filename="Terminal"}
     getent group rfriends
     rfriends:x:2000:ana,sergio
     ```
@@ -173,13 +173,13 @@ podman run
 
 2. Subordinate that GID to your user. You will need administrative permissions:
 
-    ```{.sh}
+    ```{.sh filename="Terminal"}
     sudo usermod --add-subgids 2000-2000 ana
     ```
 
 3. Update your Podman rootless namespace:
 
-    ```{.sh}
+    ```{.sh filename="Terminal"}
     podman system migrate
     ```
 
@@ -191,7 +191,7 @@ You are now able to map the group in the container. How? That depends on your Po
 To run your container mapping your host GID `2000` to a container GID combine
 the `--group-add keep-groups` with the `--gidmap` option:
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run \
     --rm \
     --group-add keep-groups \
@@ -210,7 +210,7 @@ easy way to remember the container GID and avoid collisions with lower container
 
 The command will look like:
 
-```{.sh}
+```{.sh filename="Terminal"}
 podman run  \
     --rm  \
     --group-add keep-groups \
@@ -234,7 +234,7 @@ You can notice several differences in the idmapping command:
       (using `podman unshare cat /proc/self/gid_map`).
       
 
-        ```{.sh}
+        ```{.sh filename="Terminal"}
         podman unshare cat /proc/self/gid_map
         #          0       1000          1
         #          1       2000          1

--- a/use/rootless.md
+++ b/use/rootless.md
@@ -24,6 +24,7 @@ run in [rootless](https://docs.docker.com/engine/security/rootless/) mode.
  makes it straightforward to map additional groups. This feature was 
  [contributed](https://github.com/containers/podman/pull/18713)
  by a rocker user, so you are encouraged to try it!
+
 :::
 
 

--- a/use/rootless.md
+++ b/use/rootless.md
@@ -1,8 +1,6 @@
 ---
 title: "Running Rootless"
 description: Rootless containers and rocker
-execute:
-  eval: false
 ---
 
 Docker traditionally ran as the `root` user. Users who wanted to run docker

--- a/use/rootless.md
+++ b/use/rootless.md
@@ -20,10 +20,10 @@ run in [rootless](https://docs.docker.com/engine/security/rootless/) mode.
 
 ## Podman or Docker?
 
- Podman 4.7 and above includes an extended syntax for `--uidmap` and `--gidmap` that
- makes it straightforward to map additional groups. This feature was 
- [contributed](https://github.com/containers/podman/pull/18713)
- by a rocker user, so you are encouraged to try it!
+Podman 4.7 and above includes an extended syntax for `--uidmap` and `--gidmap` that
+makes it straightforward to map additional groups. This feature was 
+[contributed](https://github.com/containers/podman/pull/18713)
+by a rocker user, so you are encouraged to try it!
 
 :::
 
@@ -227,29 +227,27 @@ You can notice several differences in the idmapping command:
 - You must provide a default user id mapping: `--uidmap "0:0:65535"`
 - You must provide a full group id mapping:
 
-    * The group id mapping should map intermediate GID 0 to container GID 0.
-      `--gidmap "0:0:1"` This maps your user to root.
+  * The group id mapping should map intermediate GID 0 to container GID 0.
+    `--gidmap "0:0:1"` This maps your user to root.
 
-    * You must find out the intermediate GID mapping for the GID you want to map 
-      (using `podman unshare cat /proc/self/gid_map`).
-      
+  * You must find out the intermediate GID mapping for the GID you want to map
+    (using `podman unshare cat /proc/self/gid_map`).
 
-        ```{.sh filename="Terminal"}
-        podman unshare cat /proc/self/gid_map
-        #          0       1000          1
-        #          1       2000          1
-        #          2     100000      65536
-        ```
 
-      By looking at the table above, you can find host GID `2000` in the middle
+    ```{.sh filename="Terminal"}
+    podman unshare cat /proc/self/gid_map
+    #          0       1000          1
+    #          1       2000          1
+    #          2     100000      65536
+    ```
+
+    By looking at the table above, you can find host GID `2000` in the middle
       column and see it is mapped to intermediate id `1` in the left column.
-      
-      So your mapping must include intermediate GID `1` to container GID `102000`:
-      `--gidmap 102000:1:1`
+    
+    So your mapping must include intermediate GID `1` to container GID `102000`:
+    `--gidmap 102000:1:1`
 
-    * And you must map container IDs from 1 to n, using free intermediate GIDs.
-      Here we map 60000: `--gidmap "1:2:60000"`.
+  * And you must map container IDs from 1 to n, using free intermediate GIDs.
+    Here we map 60000: `--gidmap "1:2:60000"`.
 
 And happy coding!
-
-

--- a/use/rootless.md
+++ b/use/rootless.md
@@ -21,7 +21,7 @@ run in [rootless](https://docs.docker.com/engine/security/rootless/) mode.
 ## Podman or Docker?
 
 Podman 4.7 and above includes an extended syntax for `--uidmap` and `--gidmap` that
-makes it straightforward to map additional groups. This feature was 
+makes it straightforward to map additional groups. This feature was
 [contributed](https://github.com/containers/podman/pull/18713)
 by a rocker user, so you are encouraged to try it!
 
@@ -243,7 +243,7 @@ You can notice several differences in the idmapping command:
 
     By looking at the table above, you can find host GID `2000` in the middle
       column and see it is mapped to intermediate id `1` in the left column.
-    
+
     So your mapping must include intermediate GID `1` to container GID `102000`:
     `--gidmap 102000:1:1`
 


### PR DESCRIPTION
This PR has a balance of 117 additions and 209 deletions.

Six months ago I wrote an article about using rocker in rootless containers.
- https://github.com/rocker-org/website/pull/93

Some settings were complicated due to limitations in the `--gidmap` syntax exposed by Podman.

As discussed there, I ended up contributing syntax enhancements to Podman.

This PR simplifies the explanations of the rootless page in the website, using the lessons learned while working on Podman. It also focuses on the `how it works` instead of the `why it works`, now that the syntax improvements make options more natural.

It preserves instructions for earlier podman versions, although upgrading is encouraged.