### PR TITLE
add r2u to nav bar and side bar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -52,6 +52,8 @@ website:
               href: images/other/r-ubuntu.md
             - text: r-bspm
               href: images/other/r-bspm.md
+            - text: r2u {{< fa arrow-up-right-from-square >}}
+              href: https://eddelbuettel.github.io/r2u
         - text: ---
         - section: Dev Container
           contents:


### PR DESCRIPTION
A follow up for https://github.com/rocker-org/website/pull/106#issuecomment-1889453273

Add the link to r2u page in the nav bar and sidebar like any other images.

![image](https://github.com/rocker-org/website/assets/50911393/514d2ecd-a477-4ab6-8e07-021b83fe9ec4)

![image](https://github.com/rocker-org/website/assets/50911393/59513278-83c0-49f5-b8d8-9f7284e8bf8e)
