### PR TITLE
Mention jupyter/docker stacks as an alternative to rocker/binder

### DIFF
--- a/images/versioned/binder.md
+++ b/images/versioned/binder.md
@@ -74,3 +74,9 @@ execute `/init` command with the root user specified.
 ```sh
 docker run --rm -ti -p 8787:8787 --user root rocker/binder /init
 ```
+
+## Alternatives
+
+If you are *primarily* interested in using the Jupyter ecosystem of tools, consider using
+the images from the [jupyter/docker-stacks](https://jupyter-docker-stacks.readthedocs.io/)
+project instead.


### PR DESCRIPTION
rocker/binder contains some Jupyter things, but the rocker project as a whole is not focused on Jupyter. This links them out to the jupyter/docker-stacks project, which is more Jupyter focused to serve users who are looking for more Jupyter focused container images. I think a lot of communities / users use a combination of Python (from various sources) and R (from the rocker project) already anyway.

I link to the rocker project from jupyter/docker-stacks since last month (https://github.com/jupyter/docker-stacks/pull/2065), and one of the maintainers asked if I could provide a link back as well.