### PR TITLE
fix name of r2u container in index (was: r-r2u)

### DIFF
--- a/images/index.md
+++ b/images/index.md
@@ -62,7 +62,7 @@ but with different build tools.
 |----------------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
 | [`rocker/r-ubuntu`](other/r-ubuntu.md) | `ubuntu`                                                                  | Close to `r-base`, but based on `ubuntu`                                                                          | ![Docker Pulls](https://img.shields.io/docker/pulls/rocker/r-ubuntu.svg) |
 | [`rocker/r-bspm`](other/r-bspm.md)     | `r-base`, `rocker/r-ubuntu`, `archlinux`, `fedora`, `opensuse/tumbleweed` | Binary installation of R packages has been configured, powered by [bspm](https://cran.r-project.org/package=bspm) | ![Docker Pulls](https://img.shields.io/docker/pulls/rocker/r-bspm.svg)   |
-| [`rocker/r-r2u`](https://eddelbuettel.github.io/r2u)     | `ubuntu`  | [r2u](https://eddelbuettel.github.io/r2u) offers all CRAN packages as binaries for Ubuntu, also uses [bspm](https://cran.r-project.org/package=bspm) | ![Docker Pulls](https://img.shields.io/docker/pulls/rocker/r2u.svg)   |
+| [`rocker/r2u`](https://eddelbuettel.github.io/r2u)     | `ubuntu`  | [r2u](https://eddelbuettel.github.io/r2u) offers all CRAN packages as binaries for Ubuntu, also uses [bspm](https://cran.r-project.org/package=bspm) | ![Docker Pulls](https://img.shields.io/docker/pulls/rocker/r2u.svg)   |
 
 
 ### Rocker Pre-built Dev Container Images


### PR DESCRIPTION
The r2u container was previously labeled as `rocker/r-r2u`; when I naively tried `docker pull rocker/r-r2u` I got (of course) "Error response from daemon: pull access denied for rocker/r-r2u, repository does not exist or may require 'docker login': denied: requested access to the resource is denied".  Took me a while to figure it out, hope this is better/helps someone else.