### PR TITLE
chore: replace twitter url

### DIFF
--- a/index.md
+++ b/index.md
@@ -45,17 +45,17 @@ For more information and further options, see [the image descriptions](images).
 
 :::{layout="[30,-5,30,-5,30]" layout-valign="center"}
 
-[![Carl](img/cboettig.jpg)](https://twitter.com/cboettig)
+[![Carl](img/cboettig.jpg)](https://github.com/cboettig)
 
-[![Dirk](img/edd.jpg)](https://twitter.com/eddelbuettel)
+[![Dirk](img/edd.jpg)](https://github.com/eddelbuettel)
 
-[![Noam](img/noamross.jpg)](https://twitter.com/noamross)
+[![Noam](img/noamross.jpg)](https://github.com/noamross)
 
 :::
 
-The Rocker project was created by [Carl Boettiger](https://twitter.com/cboettig) and [Dirk Eddelbuettel](https://twitter.com/eddelbuettel),
-and is now maintained by Carl, Dirk, [Noam Ross](https://twitter.com/noamross),
-and [SHIMA Tatsuya](https://twitter.com/eitsupi),
+The Rocker project was created by [Carl Boettiger](https://github.com/cboettig) and [Dirk Eddelbuettel](https://github.com/eddelbuettel),
+and is now maintained by Carl, Dirk, [Noam Ross](https://github.com/noamross),
+and [SHIMA Tatsuya](https://github.com/eitsupi),
 with significant contributions from a broad community of users and developers.
 Get in touch on [GitHub issues](https://github.com/rocker-org/rocker/issues) with bug reports,
 feature requests, or other feedback.

--- a/use/extending.md
+++ b/use/extending.md
@@ -176,7 +176,7 @@ Not all packages on CRAN are necessarily available.
 :::{.callout-tip}
 
 [r2u](https://eddelbuettel.github.io/r2u/),
-provided by Rocker Project member [@eddelbuettel](https://twitter.com/eddelbuettel),
+provided by Rocker Project member [@eddelbuettel](https://github.com/eddelbuettel),
 offers faster package installation on Ubuntu (amd64).
 Also, more CRAN packages and BioConductor packages are being registered.
 Please check the `r2u` document for details.


### PR DESCRIPTION
Perhaps we should replace the URL as I don't think we actively use Twitter anymore.