### PR TITLE
Clarify root user usage for rstudio when rootless

### DIFF
--- a/images/versioned/rstudio.md
+++ b/images/versioned/rstudio.md
@@ -56,7 +56,7 @@ The non-root default user `rstudio` is set up as RStudio Server user,
 so please enter the username `rstudio` and a randomly generated password
 which is displayed in the console to the RStudio login form.
 If your container system runs rootless, you will have to use the `root`
-user to login instead. In this case the privileges of the `root` user
+user to login instead, using the randomly generated password displayed in the console. In this case the privileges of the `root` user
 in the container are already bounded by your regular user permissions
 in the host system.
 

--- a/images/versioned/rstudio.md
+++ b/images/versioned/rstudio.md
@@ -55,6 +55,10 @@ docker run --rm -ti -p 8787:8787 rocker/rstudio
 The non-root default user `rstudio` is set up as RStudio Server user,
 so please enter the username `rstudio` and a randomly generated password
 which is displayed in the console to the RStudio login form.
+If your container system runs rootless, you will have to use the `root`
+user to login instead. In this case the privileges of the `root` user
+in the container are already bounded by your regular user permissions
+in the host system.
 
 RStudio will not start if the default command (`/init`) is overridden.
 To use R on the command line, specify the `R` command as follows.


### PR DESCRIPTION
Closes https://github.com/rocker-org/rocker-versioned2/issues/844

Thanks to @Tianmaru for finding and reporting the issue