### PR TITLE
Update Singularity guide

### DIFF
--- a/use/singularity.md
+++ b/use/singularity.md
@@ -49,7 +49,7 @@ PASSWORD='...' singularity exec \
    rserver --auth-none=0 --auth-pam-helper-path=pam-helper --server-user=$(whoami)
 ```
 
-After pointing your browser to http://_hostname_:8787, enter your local user ID on the system as the username, and the custom password specified in the PASSWORD environment variable.
+After pointing your browser to http://*hostname*:8787, enter your local user ID on the system as the username, and the custom password specified in the PASSWORD environment variable.
 
 ## Additional Options for RStudio >= 1.3.x
 

--- a/use/singularity.md
+++ b/use/singularity.md
@@ -89,13 +89,11 @@ workdir=$(mktemp -d)
 # Set R_LIBS_USER to an existing path specific to rocker/rstudio to avoid conflicts with
 # personal libraries from any R installation in the host environment
 
-R_LIBS_USER=${HOME}/R/rocker-rstudio/4.4.2
-mkdir -p "${R_LIBS_USER}"
-
 cat > ${workdir}/rsession.sh <<END
 #!/bin/sh
 export OMP_NUM_THREADS=${SLURM_CPUS_ON_NODE}
-export R_LIBS_USER="${R_LIBS_USER}"
+export R_LIBS_USER=${HOME}/R/rocker-rstudio/4.4.2
+mkdir -p "\${R_LIBS_USER}"
 ## custom Rprofile & Renviron (default is $HOME/.Rprofile and $HOME/.Renviron)
 # export R_PROFILE_USER=/path/to/Rprofile
 # export R_ENVIRON_USER=/path/to/Renviron

--- a/use/singularity.md
+++ b/use/singularity.md
@@ -9,8 +9,10 @@ aliases:
 Rocker images can be imported and run using Singularity, with optional custom password support.
 
 :::{.callout-note}
+
 In this guide, *Singularity* can refer to either [SingularityCE](https://sylabs.io/singularity/) or [Apptainer](https://apptainer.org/).
 While Apptainer is generally [compatible with Singularity commands and environment variables](https://apptainer.org/docs/user/latest/singularity_compatibility.html), Apptainer users may wish to replace the `singularity` command with `apptainer`, and `SINGULARITY` with `APPTAINER` in environment variables.
+
 :::
 
 ## Importing a Rocker Image

--- a/use/singularity.md
+++ b/use/singularity.md
@@ -82,22 +82,17 @@ The following example illustrates how this may be done with a SLURM job script.
 # where writable file systems are necessary. Adjust path as appropriate for your computing environment.
 workdir=$(mktemp -d)
 
-# Set OMP_NUM_THREADS to prevent OpenBLAS (and any other OpenMP-enhanced
-# libraries used by R) from spawning more threads than the number of processors
-# allocated to the job.
-#
 # Set R_LIBS_USER to an existing path specific to rocker/rstudio to avoid conflicts with
 # personal libraries from any R installation in the host environment
 
-cat > ${workdir}/rsession.sh <<END
+cat > ${workdir}/rsession.sh <<"END"
 #!/bin/sh
-export OMP_NUM_THREADS=${SLURM_CPUS_ON_NODE}
 export R_LIBS_USER=${HOME}/R/rocker-rstudio/4.4.2
-mkdir -p "\${R_LIBS_USER}"
+mkdir -p "${R_LIBS_USER}"
 ## custom Rprofile & Renviron (default is $HOME/.Rprofile and $HOME/.Renviron)
 # export R_PROFILE_USER=/path/to/Rprofile
 # export R_ENVIRON_USER=/path/to/Renviron
-exec /usr/lib/rstudio-server/bin/rsession "\${@}"
+exec /usr/lib/rstudio-server/bin/rsession "${@}"
 END
 
 chmod +x ${workdir}/rsession.sh


### PR DESCRIPTION
Updates the Singularity guide:

* Set `rserver --server-user` in job script (https://github.com/rocker-org/rocker-versioned2/issues/837)
* Show where R_PROFILE_USER and R_LIBS_USER can be set
  (https://github.com/rocker-org/rocker-versioned2/issues/855)
*  Use rocker/rstudio:4.4.2
* Specify `python3` instead of `python` (the latter may be python 2 or absent on some hosts)
* Mention Apptainer
* mktemp is simpler and portable-enough (GNU coreutils) for creating temp dirs
* Simplify creation of various writable directories in container with `--scratch` and `--workdir`
* Ensure R_LIBS_USER directory exists
* no longer need to create readable database.conf (sqlite seems to be the default)
* SLURM_CPUS_ON_NODE technically more correct than SLURM_JOB_CPUS_PER_NODE
  (though shouldn't make a difference with a single-node allocation)
